### PR TITLE
protect fire() function from being run in fastboot

### DIFF
--- a/addon/services/confetti.js
+++ b/addon/services/confetti.js
@@ -14,6 +14,12 @@ export default class ConfettiService extends Service {
   }
 
   async fire(options) {
+    // canvas-confetti makes use of the document and it doesn't really make
+    // sense to run it in fastboot
+    if (typeof FastBoot !== 'undefined') {
+      return;
+    }
+
     let fire = await this.load();
     return fire(options);
   }


### PR DESCRIPTION
There is a bit of an obscure guide on the ember-fastboot.com website for addon authors (that could really be totally re-written and simplified).

but essentially this section https://ember-fastboot.com/docs/addon-author-guide#browser-only-initializers suggests checking the `typeof FastBoot` and if it's `'undefined'` then you know that you're running in the browser and not in fastboot. 

There is another way to do it with the fastboot service but that requires that service to be available in your consuming application (i.e. ember-cli-fastboot needs to be installed), so using the `typeof` trick makes for slightly better addons